### PR TITLE
[Upd] Use webpack for production bundle compilation

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "react": ">= 16.9.0",
     "react-dom": ">= 16.9.0"
   },
-  "main": "lib/s-forms.js",
+  "main": "dist/s-forms.js",
   "private": true,
   "devDependencies": {
     "@babel/cli": "^7.8.4",
@@ -86,11 +86,11 @@
     "dev": "webpack-dev-server --config webpack.config.dev.js",
     "build": "webpack --config webpack.config.prod.js",
     "lib": "babel ./src -d ./lib",
-    "build:lib": "npm run build:css && npm run lib && npm pack",
+    "build:lib": "npm run build && npm run build:css && npm pack",
     "build:css": "cleancss --skip-rebase -d -o ./css/s-forms.min.css ./src/styles/s-forms.css"
   },
   "files": [
-    "lib/",
+    "dist/",
     "css/",
     "types/"
   ],


### PR DESCRIPTION
This update fixes tests in Study Manager. 
There was a problem with importing component from s-forms.

I believe that this is one of the correct ways how to create a production bundle of libraries—the solution before I saw only in KBSS's built libraries, anywhere else.