### PR TITLE
Refaktor + přesunuti enableForwardSkip a startingStep do options

### DIFF
--- a/src/components/wizard/Wizard.jsx
+++ b/src/components/wizard/Wizard.jsx
@@ -8,11 +8,13 @@ import { ConfigurationContext } from '../../contexts/ConfigurationContext';
 import WizardWindow from './WizardWindow';
 import { WizardContext } from '../../contexts/WizardContext';
 
-const Wizard = (props) => {
-  const [currentStep, setCurrentStep] = React.useState(props.start || 0);
-
+const Wizard = () => {
   const wizardContext = React.useContext(WizardContext);
-  const configurationContext = React.useContext(ConfigurationContext);
+  const { options } = React.useContext(ConfigurationContext);
+
+  const start = options.startingStep < wizardContext.getStepData().length ? options.startingStep : 0;
+
+  const [currentStep, setCurrentStep] = React.useState(start);
 
   const onNextStep = () => {
     const stepData = wizardContext.getStepData();
@@ -36,7 +38,7 @@ const Wizard = (props) => {
       return;
     }
     // Can we jump forward?
-    if (stepIndex > currentStep && !stepData[stepIndex].visited && !props.enableForwardSkip) {
+    if (stepIndex > currentStep && !stepData[stepIndex].visited && !options.enableForwardSkip) {
       return;
     }
     setCurrentStep(stepIndex);
@@ -49,7 +51,7 @@ const Wizard = (props) => {
 
     const stepData = wizardContext.getStepData();
 
-    return configurationContext.options.horizontalWizardNav ? (
+    return options.horizontalWizardNav ? (
       <HorizontalWizardNav currentStep={currentStep} steps={stepData} onNavigate={navigate} />
     ) : (
       <VerticalWizardNav currentStep={currentStep} steps={stepData} onNavigate={navigate} />
@@ -57,7 +59,7 @@ const Wizard = (props) => {
   };
 
   const renderWizard = () => {
-    const isHorizontal = configurationContext.options.horizontalWizardNav;
+    const isHorizontal = options.horizontalWizardNav;
 
     const cardClassname = isHorizontal ? '' : 'flex-row p-2';
     const containerClassname = isHorizontal ? 'card-body' : 'col-10 p-0';
@@ -92,16 +94,11 @@ const Wizard = (props) => {
     );
   };
 
-  if (configurationContext.options.modalView) {
+  if (options.modalView) {
     return <WizardWindow>{renderWizard()}</WizardWindow>;
   }
 
   return renderWizard();
-};
-
-Wizard.propTypes = {
-  start: PropTypes.number,
-  enableForwardSkip: PropTypes.bool // Whether to allow forward step skipping
 };
 
 export default Wizard;

--- a/src/components/wizard/Wizard.jsx
+++ b/src/components/wizard/Wizard.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import { Card } from 'react-bootstrap';
 import WizardStep from './WizardStep';
 import HorizontalWizardNav from './HorizontalWizardNav';
@@ -85,8 +84,8 @@ const Wizard = () => {
       <WizardStep
         key={'step' + currentStep}
         step={step}
-        onNext={onNextStep}
-        onPrevious={onPreviousStep}
+        onNextStep={onNextStep}
+        onPreviousStep={onPreviousStep}
         stepIndex={currentStep}
         isFirstStep={currentStep === 0}
         isLastStep={currentStep === wizardContext.getStepData().length - 1}

--- a/src/components/wizard/Wizard.jsx
+++ b/src/components/wizard/Wizard.jsx
@@ -14,68 +14,29 @@ const Wizard = (props) => {
   const wizardContext = React.useContext(WizardContext);
   const configurationContext = React.useContext(ConfigurationContext);
 
-  const onAdvance = () => {
-    if (currentStep !== wizardContext.getStepData().length - 1) {
-      wizardContext.getStepData()[currentStep + 1].visited = true;
+  const onNextStep = () => {
+    const stepData = wizardContext.getStepData();
+    if (currentStep !== stepData.length - 1) {
+      stepData[currentStep + 1].visited = true;
       setCurrentStep((prevCurrentStep) => prevCurrentStep + 1);
     }
   };
 
-  const onRetreat = () => {
+  const onPreviousStep = () => {
     if (currentStep === 0) {
       return;
     }
     setCurrentStep((prevCurrentStep) => prevCurrentStep - 1);
   };
 
-  const onFinish = (errCallback) => {
-    const data = {
-      data: this.context.getData(),
-      stepData: this.context.getStepData()
-    };
-    this.context.reset();
-    this.props.onFinish(data, this.props.onClose, errCallback);
-  };
-
-  /**
-   * Insert the specified step after the current one.
-   * @param step The step to insert
-   */
-  const onInsertStepAfterCurrent = (step) => {
-    configurationContext.getStepData().splice(currentStep + 1, 0, step);
-    configurationContext.insertStep(currentStep + 1, step);
-  };
-
-  /**
-   * Adds the specified step to the end of this wizard.
-   * @param step The step to add
-   */
-  const onAddStep = (step) => {
-    wizardContext.getStepData().push(step);
-    wizardContext.insertStep(wizardContext.getStepData().length - 1, step);
-  };
-
-  const onRemoveStep = (stepId) => {
+  const navigate = (stepIndex) => {
     const stepData = wizardContext.getStepData();
 
-    for (let i = 0; i < stepData.length; i++) {
-      if (stepData[i].id === stepId) {
-        wizardContext.getStepData().splice(i, 1);
-        wizardContext.removeStep(i);
-        if (i === currentStep && i !== 0) {
-          setCurrentStep((prevCurrentStep) => prevCurrentStep - 1);
-        }
-        break;
-      }
-    }
-  };
-
-  const navigate = (stepIndex) => {
-    if (stepIndex === currentStep || stepIndex >= wizardContext.getStepData().length) {
+    if (stepIndex === currentStep || stepIndex >= stepData.length) {
       return;
     }
     // Can we jump forward?
-    if (stepIndex > currentStep && !wizardContext.getStepData()[stepIndex].visited && !props.enableForwardSkip) {
+    if (stepIndex > currentStep && !stepData[stepIndex].visited && !props.enableForwardSkip) {
       return;
     }
     setCurrentStep(stepIndex);
@@ -86,10 +47,12 @@ const Wizard = (props) => {
       return null;
     }
 
+    const stepData = wizardContext.getStepData();
+
     return configurationContext.options.horizontalWizardNav ? (
-      <HorizontalWizardNav currentStep={currentStep} steps={wizardContext.getStepData()} onNavigate={navigate} />
+      <HorizontalWizardNav currentStep={currentStep} steps={stepData} onNavigate={navigate} />
     ) : (
-      <VerticalWizardNav currentStep={currentStep} steps={wizardContext.getStepData()} onNavigate={navigate} />
+      <VerticalWizardNav currentStep={currentStep} steps={stepData} onNavigate={navigate} />
     );
   };
 
@@ -120,12 +83,8 @@ const Wizard = (props) => {
       <WizardStep
         key={'step' + currentStep}
         step={step}
-        onFinish={onFinish}
-        onAdvance={onAdvance}
-        onRetreat={onRetreat}
-        onInsertStepAfterCurrent={onInsertStepAfterCurrent}
-        onAddStep={onAddStep}
-        onRemoveStep={onRemoveStep}
+        onNext={onNextStep}
+        onPrevious={onPreviousStep}
         stepIndex={currentStep}
         isFirstStep={currentStep === 0}
         isLastStep={currentStep === wizardContext.getStepData().length - 1}
@@ -142,8 +101,6 @@ const Wizard = (props) => {
 
 Wizard.propTypes = {
   start: PropTypes.number,
-  onFinish: PropTypes.func,
-  onClose: PropTypes.func,
   enableForwardSkip: PropTypes.bool // Whether to allow forward step skipping
 };
 

--- a/src/components/wizard/WizardStep.jsx
+++ b/src/components/wizard/WizardStep.jsx
@@ -12,51 +12,14 @@ const WizardStep = (props) => {
   const wizardContext = React.useContext(WizardContext);
   const { options } = React.useContext(ConfigurationContext);
 
-  const [advanceDisabled, setAdvanceDisabled] = useState(
-    props.step.defaultNextDisabled != null ? props.step.defaultNextDisabled : false
-  );
-  const [retreatDisabled, setRetreatDisabled] = useState(false);
-  const [currentError, setCurrentError] = useState(null);
-
-  const onAdvance = (err) => {
-    if (err) {
-      setAdvanceDisabled(true);
-      setRetreatDisabled(true);
-      setCurrentError(err);
-    } else {
-      wizardContext.updateStepData(props.stepIndex, wizardContext.getStepData());
-      props.onAdvance();
-    }
-  };
-
-  const onNext = () => {
-    setAdvanceDisabled(true);
-    setRetreatDisabled(true);
-
-    if (props.step.onNext) {
-      props.step.onNext.apply(this, [onAdvance]);
-    } else {
-      wizardContext.updateStepData(props.stepIndex, wizardContext.getStepData());
-      props.onAdvance();
-    }
-  };
-
-  const onPrevious = () => {
-    if (props.step.onPrevious) {
-      props.step.onPrevious.apply(this, [props.onRetreat]);
-    } else {
-      props.onRetreat();
-    }
-  };
-
-  const onFinish = () => {
+  const onNextStep = () => {
     wizardContext.updateStepData(props.stepIndex, wizardContext.getStepData());
-    props.onFinish();
+    props.onNextStep();
   };
 
-  const enableNext = () => setAdvanceDisabled(false);
-
-  const disableNext = () => setAdvanceDisabled(true);
+  const onPreviousStep = () => {
+    props.onPreviousStep();
+  };
 
   const _renderHelpIcon = () => {
     const question = wizardContext.getStepData([props.stepIndex]);
@@ -73,12 +36,12 @@ const WizardStep = (props) => {
     return (
       <ButtonToolbar className="m-3 float-right">
         {!props.isFirstStep && (
-          <Button className="mr-2" onClick={onPrevious} disabled={retreatDisabled} variant="primary" size="sm">
+          <Button className="mr-2" onClick={onPreviousStep} variant="primary" size="sm">
             {options.i18n['wizard.previous']}
           </Button>
         )}
         {!props.isLastStep && (
-          <Button onClick={onNext} disabled={advanceDisabled} variant="primary" size="sm">
+          <Button onClick={onNextStep} variant="primary" size="sm">
             {options.i18n['wizard.next']}
           </Button>
         )}
@@ -99,21 +62,14 @@ const WizardStep = (props) => {
       </Card>
 
       {options.wizardStepButtons && _renderWizardStepButtons()}
-
-      {currentError && (
-        <Alert variant="danger">
-          <p>{currentError.message}</p>
-        </Alert>
-      )}
     </div>
   );
 };
 
 WizardStep.propTypes = {
   step: PropTypes.object.isRequired,
-  onFinish: PropTypes.func.isRequired,
-  onAdvance: PropTypes.func,
-  onRetreat: PropTypes.func,
+  onNextStep: PropTypes.func,
+  onPreviousStep: PropTypes.func,
   stepIndex: PropTypes.number.isRequired,
   isFirstStep: PropTypes.bool,
   isLastStep: PropTypes.bool

--- a/src/contexts/ConfigurationContext.js
+++ b/src/contexts/ConfigurationContext.js
@@ -20,7 +20,9 @@ const defaultProps = {
     modalView: false,
     modalProps: {},
     horizontalWizardNav: true,
-    wizardStepButtons: true
+    wizardStepButtons: true,
+    enableForwardSkip: false,
+    startingStep: 0
   }
 };
 

--- a/src/contexts/WizardContext.js
+++ b/src/contexts/WizardContext.js
@@ -38,25 +38,6 @@ const WizardContextProvider = (props) => {
     }
   };
 
-  const insertStep = (index, update) => {
-    const newStepData = [...stepData];
-
-    newStepData.splice(index, 0, update || {});
-    setStepData(newStepData);
-  };
-
-  const removeStep = (index) => {
-    const newStepData = [...stepData];
-
-    newStepData.splice(index, 1);
-    setStepData(newStepData);
-  };
-
-  const reset = () => {
-    setData(INITIAL_DATA);
-    setStepData(INITIAL_STEP_DATA);
-  };
-
   const getData = () => {
     return data;
   };
@@ -69,9 +50,6 @@ const WizardContextProvider = (props) => {
     () => ({
       updateData,
       updateStepData,
-      insertStep,
-      removeStep,
-      reset,
       getData,
       getStepData
     }),

--- a/test/rendering/TestApp.jsx
+++ b/test/rendering/TestApp.jsx
@@ -39,7 +39,9 @@ class TestApp extends React.Component {
       modalView: false,
       modalProps,
       horizontalWizardNav: true,
-      wizardStepButtons: true
+      wizardStepButtons: true,
+      enableForwardSkip: true,
+      startingStep: 1
     };
 
     return (
@@ -50,7 +52,6 @@ class TestApp extends React.Component {
           options={options}
           fetchTypeAheadValues={this.fetchTypeAheadValues}
           isFormValid={(isFormValid) => this.setState({ isFormValid })}
-          enableForwardSkip={true}
         />
         <button
           disabled={!this.state.isFormValid}

--- a/types/s-forms.d.ts
+++ b/types/s-forms.d.ts
@@ -11,6 +11,8 @@ export interface SOptions {
   modalProps?: Modal;
   horizontalWizardNav?: boolean; // default true
   wizardStepButtons?: boolean; // default true
+  enableForwardSkip?: boolean; // default false
+  startingStep?: number; // default 0; indexed from 0
 }
 
 export interface SComponents {


### PR DESCRIPTION
Pokud použivas enableForwardSkip, tak se přesouva do options a je spravne zdokumentovane v d.ts filu

Zaroven jsem zrefaktoroval ješte Wizard, jelikož tam byly funkce, které se nikdy nezavolaly