### PR TITLE
Support hiding icons related to question

### DIFF
--- a/src/components/Answer.jsx
+++ b/src/components/Answer.jsx
@@ -139,7 +139,7 @@ const Answer = (props) => {
     return (
         <div className="question-header">
           {label}
-          {Question.renderIcons(props.question, options, props.onCommentChange)}
+          {Question.renderIcons(props.question, options, props.onCommentChange, props.showIcon)}
         </div>
     );
   }

--- a/src/components/Question.jsx
+++ b/src/components/Question.jsx
@@ -379,7 +379,11 @@ export default class Question extends React.Component {
   static renderQuestionHelp(question, options, onCommentChange, showIcon) {
     const icons = options.icons;
     let questionHelpIcon;
-    if (!icons) questionHelpIcon = {id: Constants.ICONS.QUESTION_HELP, behavior:  Constants.ICON_BEHAVIOR.ENABLE};
+    if (!icons) {
+      questionHelpIcon = Constants.DEFAULT_OPTIONS.icons.find(icon => {
+        return icon.id === Constants.ICONS.QUESTION_HELP
+      });
+    }
     else questionHelpIcon = this.getIconFromIconList(icons, Constants.ICONS.QUESTION_HELP);
     return this.getIconComponent(questionHelpIcon, question, options, onCommentChange, showIcon);
   }
@@ -387,33 +391,23 @@ export default class Question extends React.Component {
   static renderQuestionComments = (question, options, onCommentChange, showIcon) => {
     const icons = options.icons;
     let questionCommentsIcon;
-    if (!icons) questionCommentsIcon = {id: Constants.ICONS.QUESTION_COMMENTS, behavior: Constants.ICON_BEHAVIOR.ON_HOVER};
+    if (!icons) {
+      questionCommentsIcon = Constants.DEFAULT_OPTIONS.icons.find(icon => {
+        return icon.id === Constants.ICONS.QUESTION_COMMENTS
+      });
+    }
     else questionCommentsIcon = this.getIconFromIconList(icons, Constants.ICONS.QUESTION_COMMENTS);
     return this.getIconComponent(questionCommentsIcon, question, options, onCommentChange, showIcon);
   }
 
   static renderIcons(question, options, onCommentChange, showIcon) {
-    const icons = options.icons;
+    let icons;
+    if (options.icons) icons = options.icons;
+    else icons = Constants.DEFAULT_OPTIONS.icons;
     let iconsArray = [];
     const renderQuestionHelp = Question.renderQuestionHelp(question, options, onCommentChange, showIcon);
     const renderQuestionComments = Question.renderQuestionComments(question, options, onCommentChange, showIcon);
 
-    if (icons) this.sortIcons(icons, iconsArray, renderQuestionComments, renderQuestionHelp);
-    else {
-      iconsArray.push(
-          <React.Fragment key={Math.random()}>
-            <li className="icon-list-item">{renderQuestionHelp}</li>
-            <li className="icon-list-item">{renderQuestionComments}</li>
-          </React.Fragment>
-      );
-    }
-
-    return (<ol className="icon-list-items">
-      {iconsArray}
-    </ol>);
-  }
-
-  static sortIcons(icons, iconsArray, renderQuestionComments, renderQuestionHelp) {
     for (let i = 0; i < icons.length; i++) {
       if (icons[i].id === Constants.ICONS.QUESTION_COMMENTS) {
         iconsArray.push(
@@ -426,6 +420,10 @@ export default class Question extends React.Component {
         );
       }
     }
+
+    return (<ol className="icon-list-items">
+      {iconsArray}
+    </ol>);
   }
 
   _renderPrefixes() {

--- a/src/components/Question.jsx
+++ b/src/components/Question.jsx
@@ -16,6 +16,8 @@ import {CaretSquareDown, CaretSquareUp, InfoCircle} from '../styles/icons';
 import {ConfigurationContext} from '../contexts/ConfigurationContext';
 import classNames from 'classnames';
 import QuestionCommentIcon from "./comment/QuestionCommentIcon";
+import ExternalLink from "../styles/icons/ExternalLink";
+import LinkIcon from "./LinkIcon";
 
 // TODO Remove once the pretty layout is tested
 const PRETTY_ANSWERABLE_LAYOUT = true;
@@ -376,28 +378,18 @@ export default class Question extends React.Component {
     return null;
   }
 
+  static getIconComponentFromName(iconName, question, options, onCommentChange, showIcon) {
+    const iconList = (options.icons) ? options.icons : Constants.DEFAULT_OPTIONS.icons;
+    const icon = this.getIconFromIconList(iconList, iconName);
+    return this.getIconComponent(icon, question, options, onCommentChange, showIcon);
+  }
+
   static renderQuestionHelp(question, options, onCommentChange, showIcon) {
-    const icons = options.icons;
-    let questionHelpIcon;
-    if (!icons) {
-      questionHelpIcon = Constants.DEFAULT_OPTIONS.icons.find(icon => {
-        return icon.id === Constants.ICONS.QUESTION_HELP
-      });
-    }
-    else questionHelpIcon = this.getIconFromIconList(icons, Constants.ICONS.QUESTION_HELP);
-    return this.getIconComponent(questionHelpIcon, question, options, onCommentChange, showIcon);
+    return this.getIconComponentFromName(Constants.ICONS.QUESTION_HELP, question, options, onCommentChange, showIcon);
   }
 
   static renderQuestionComments = (question, options, onCommentChange, showIcon) => {
-    const icons = options.icons;
-    let questionCommentsIcon;
-    if (!icons) {
-      questionCommentsIcon = Constants.DEFAULT_OPTIONS.icons.find(icon => {
-        return icon.id === Constants.ICONS.QUESTION_COMMENTS
-      });
-    }
-    else questionCommentsIcon = this.getIconFromIconList(icons, Constants.ICONS.QUESTION_COMMENTS);
-    return this.getIconComponent(questionCommentsIcon, question, options, onCommentChange, showIcon);
+    return this.getIconComponentFromName(Constants.ICONS.QUESTION_COMMENTS, question, options, onCommentChange, showIcon);
   }
 
   static renderIcons(question, options, onCommentChange, showIcon) {

--- a/src/components/Question.jsx
+++ b/src/components/Question.jsx
@@ -334,32 +334,38 @@ export default class Question extends React.Component {
   }
 
   static getIconComponent(icon, question, options, onCommentChange, showIcon) {
+    let iconClassname;
+
     if (icon && (icon.behavior === Constants.ICON_BEHAVIOR.ON_HOVER || icon.behavior === Constants.ICON_BEHAVIOR.ENABLE)) {
-      if (icon.behavior === Constants.ICON_BEHAVIOR.ENABLE) showIcon = true;
+      if (icon.behavior === Constants.ICON_BEHAVIOR.ENABLE){
+        showIcon = true;
+        iconClassname = "";
+      } else iconClassname = "emphasise-on-relevant-short";
+
       if (icon.id === Constants.ICONS.QUESTION_HELP && question[Constants.HELP_DESCRIPTION]) {
-        return (
-            <>
-              {showIcon ? <div className="emphasise-on-relevant-short">
-                    <HelpIcon
-                        text={JsonLdUtils.getLocalized(question[Constants.HELP_DESCRIPTION], options.intl)}
-                        absolutePosition={false}/>
-                  </div>
-                  : null}
-            </>
-        );
+        if (showIcon) {
+          return (
+              <div className={iconClassname}>
+                <HelpIcon
+                    text={JsonLdUtils.getLocalized(question[Constants.HELP_DESCRIPTION], options.intl)}
+                    absolutePosition={false}/>
+              </div>
+          );
+        }
+        return null;
       }
 
       if (icon.id === Constants.ICONS.QUESTION_COMMENTS) {
-        return (
-            <>
-              {showIcon ? <div className="emphasise-on-relevant-short">
-                    <QuestionCommentIcon
-                        question={question}
-                        onChange={onCommentChange}/>
-                  </div>
-                  : null}
-            </>
-        );
+        if (showIcon) {
+          return (
+              <div className={iconClassname}>
+                <QuestionCommentIcon
+                    question={question}
+                    onChange={onCommentChange}/>
+              </div>
+          );
+        }
+        return null;
       }
       return null;
     }

--- a/src/components/Question.jsx
+++ b/src/components/Question.jsx
@@ -340,7 +340,7 @@ export default class Question extends React.Component {
       if (icon.behavior === Constants.ICON_BEHAVIOR.ENABLE){
         showIcon = true;
         iconClassname = "";
-      } else iconClassname = "emphasise-on-relevant-short";
+      } else iconClassname = "emphasise-on-relevant-icon";
 
       if (icon.id === Constants.ICONS.QUESTION_HELP && question[Constants.HELP_DESCRIPTION]) {
         if (showIcon) {

--- a/src/components/Question.jsx
+++ b/src/components/Question.jsx
@@ -26,7 +26,8 @@ export default class Question extends React.Component {
     JsonLdObjectMap.putObject(props.question['@id'], props.question);
     this.state = {
       validator: null,
-      expanded: !FormUtils.isCollapsed(props.question)
+      expanded: !FormUtils.isCollapsed(props.question),
+      showIcon: false
     };
   }
 
@@ -95,6 +96,14 @@ export default class Question extends React.Component {
     }
   };
 
+  _onMouseEnterHandler = () => {
+    this.setState({ showIcon: true });
+  };
+
+  _onMouseLeaveHandler = () => {
+    this.setState({ showIcon: false });
+  };
+
   render() {
     const question = this.props.question;
     const options = this.context.options;
@@ -149,14 +158,18 @@ export default class Question extends React.Component {
       return (
           <Accordion defaultActiveKey={!this.state.expanded ? label : undefined}>
             <Card className="mb-3">
-              <Accordion.Toggle as={Card.Header} onClick={this._toggleCollapse} className={headerClassName + " question-header"}>
-                    <h6 className="d-inline" id={question['@id']}>
-                      {collapsible && this._renderCollapseToggle()}
-                      {label}
-                    </h6>
-                <div>
-                  {Question.renderIcons(question, options, this.onCommentChange)}
-                </div>
+              <Accordion.Toggle
+                  as={Card.Header}
+                  onClick={this._toggleCollapse}
+                  className={headerClassName + " question-header"}
+                  onMouseEnter={this._onMouseEnterHandler}
+                  onMouseLeave={this._onMouseLeaveHandler}
+              >
+                <h6 className="d-inline" id={question['@id']}>
+                  {collapsible && this._renderCollapseToggle()}
+                  {label}
+                </h6>
+                {Question.renderIcons(question, options, this.onCommentChange, this.state.showIcon)}
               </Accordion.Toggle>
               {collapsible ? <Accordion.Collapse>{cardBody}</Accordion.Collapse> : { cardBody }}
             </Card>
@@ -226,7 +239,12 @@ export default class Question extends React.Component {
         Question.getEmphasizedOnRelevantClass(question)
       );
       children.push(
-        <div key={'row-item-' + i} className={cls} id={question['@id']}>
+        <div key={'row-item-' + i}
+             className={cls}
+             id={question['@id']}
+             onMouseEnter={this._onMouseEnterHandler}
+             onMouseLeave={this._onMouseLeaveHandler}
+        >
           <div className="answer-content" style={this._getAnswerWidthStyle()}>
             <Answer
                 index={i}
@@ -234,6 +252,7 @@ export default class Question extends React.Component {
                 question={question}
                 onChange={this.onAnswerChange}
                 onCommentChange={this.onCommentChange}
+                showIcon={this.state.showIcon}
             />
           </div>
           {this._renderUnits()}
@@ -314,61 +333,93 @@ export default class Question extends React.Component {
     );
   }
 
-  static getIconComponent(icon, question, options, onCommentChange) {
-    if (icon && icon.behavior === Constants.ICON_BEHAVIOR.ENABLE) {
+  static getIconComponent(icon, question, options, onCommentChange, showIcon) {
+    if (icon && (icon.behavior === Constants.ICON_BEHAVIOR.ON_HOVER || icon.behavior === Constants.ICON_BEHAVIOR.ENABLE)) {
+      if (icon.behavior === Constants.ICON_BEHAVIOR.ENABLE) showIcon = true;
       if (icon.id === Constants.ICONS.QUESTION_HELP && question[Constants.HELP_DESCRIPTION]) {
-        return <HelpIcon
-            text={JsonLdUtils.getLocalized(question[Constants.HELP_DESCRIPTION], options.intl)}
-            absolutePosition={false}/>
+        return (
+            <>
+              {showIcon ? <div className="emphasise-on-relevant-short">
+                    <HelpIcon
+                        text={JsonLdUtils.getLocalized(question[Constants.HELP_DESCRIPTION], options.intl)}
+                        absolutePosition={false}/>
+                  </div>
+                  : null}
+            </>
+        );
       }
 
       if (icon.id === Constants.ICONS.QUESTION_COMMENTS) {
-        return <QuestionCommentIcon
-            question={question}
-            onChange={onCommentChange}/>
+        return (
+            <>
+              {showIcon ? <div className="emphasise-on-relevant-short">
+                    <QuestionCommentIcon
+                        question={question}
+                        onChange={onCommentChange}/>
+                  </div>
+                  : null}
+            </>
+        );
       }
+      return null;
     }
-    return null;
   }
 
   static getIconFromIconList = (iconList, iconName) => {
-    return iconList.find(icon => icon.id === iconName);
+    if (iconList) return iconList.find(icon => icon.id === iconName);
+    return null;
   }
 
-  static renderQuestionHelp(question, options, onCommentChange) {
+  static renderQuestionHelp(question, options, onCommentChange, showIcon) {
     const icons = options.icons;
-    const questionHelpIcon = this.getIconFromIconList(icons, Constants.ICONS.QUESTION_HELP)
-    return this.getIconComponent(questionHelpIcon, question, options, onCommentChange);
+    let questionHelpIcon;
+    if (!icons) questionHelpIcon = {id: Constants.ICONS.QUESTION_HELP, behavior:  Constants.ICON_BEHAVIOR.ENABLE};
+    else questionHelpIcon = this.getIconFromIconList(icons, Constants.ICONS.QUESTION_HELP);
+    return this.getIconComponent(questionHelpIcon, question, options, onCommentChange, showIcon);
   }
 
-  static renderQuestionComments = (question, options, onCommentChange) => {
+  static renderQuestionComments = (question, options, onCommentChange, showIcon) => {
     const icons = options.icons;
-    const questionCommentsIcon = this.getIconFromIconList(icons, Constants.ICONS.QUESTION_COMMENTS)
-    return this.getIconComponent(questionCommentsIcon, question, options, onCommentChange);
+    let questionCommentsIcon;
+    if (!icons) questionCommentsIcon = {id: Constants.ICONS.QUESTION_COMMENTS, behavior: Constants.ICON_BEHAVIOR.ON_HOVER};
+    else questionCommentsIcon = this.getIconFromIconList(icons, Constants.ICONS.QUESTION_COMMENTS);
+    return this.getIconComponent(questionCommentsIcon, question, options, onCommentChange, showIcon);
   }
 
-  static renderIcons(question, options, onCommentChange) {
+  static renderIcons(question, options, onCommentChange, showIcon) {
     const icons = options.icons;
     let iconsArray = [];
-    const renderQuestionHelp = Question.renderQuestionHelp(question, options);
-    const renderQuestionComments = Question.renderQuestionComments(question, options, onCommentChange);
+    const renderQuestionHelp = Question.renderQuestionHelp(question, options, onCommentChange, showIcon);
+    const renderQuestionComments = Question.renderQuestionComments(question, options, onCommentChange, showIcon);
 
-    for (let i = 0; i < icons.length; i++) {
-      if (icons[i].id === Constants.ICONS.QUESTION_COMMENTS) {
-        iconsArray.push(
-            <li key={i} className="icon-list-item">{renderQuestionComments}</li>
-        )
-      }
-      if (icons[i].id === Constants.ICONS.QUESTION_HELP) {
-        iconsArray.push(
-            <li key={i} className="icon-list-item">{renderQuestionHelp}</li>
-        )
-      }
+    if (icons) this.sortIcons(icons, iconsArray, renderQuestionComments, renderQuestionHelp);
+    else {
+      iconsArray.push(
+          <React.Fragment key={Math.random()}>
+            <li className="icon-list-item">{renderQuestionHelp}</li>
+            <li className="icon-list-item">{renderQuestionComments}</li>
+          </React.Fragment>
+      );
     }
 
     return (<ol className="icon-list-items">
       {iconsArray}
     </ol>);
+  }
+
+  static sortIcons(icons, iconsArray, renderQuestionComments, renderQuestionHelp) {
+    for (let i = 0; i < icons.length; i++) {
+      if (icons[i].id === Constants.ICONS.QUESTION_COMMENTS) {
+        iconsArray.push(
+            <li key={i} className="icon-list-item">{renderQuestionComments}</li>
+        );
+      }
+      if (icons[i].id === Constants.ICONS.QUESTION_HELP) {
+        iconsArray.push(
+            <li key={i} className="icon-list-item">{renderQuestionHelp}</li>
+        );
+      }
+    }
   }
 
   _renderPrefixes() {

--- a/src/components/wizard/WizardStep.jsx
+++ b/src/components/wizard/WizardStep.jsx
@@ -9,9 +9,11 @@ import JsonLdObjectMap from "../../util/JsonLdObjectMap";
 
 
 export default class WizardStep extends React.Component {
-
   constructor(props) {
     super(props);
+    this.state = {
+      showIcon: false
+    }
   }
 
   onNextStep = () => {
@@ -56,6 +58,14 @@ export default class WizardStep extends React.Component {
     this.context.updateFormQuestionsData(this.props.stepIndex || index, { ...this.props.step, ...change });
   };
 
+  _onMouseEnterHandler = () => {
+    this.setState({ showIcon: true });
+  };
+
+  _onMouseLeaveHandler = () => {
+    this.setState({ showIcon: false });
+  };
+
   render() {
 
     const categoryClass = Question._getQuestionCategoryClass(this.props.step);
@@ -73,9 +83,15 @@ export default class WizardStep extends React.Component {
     return (
       <div className="wizard-step">
         <Card className="wizard-step-content">
-          <Card.Header className="bg-primary text-white question-header" as="h6" id={this.props.step['@id']}>
+          <Card.Header
+              className="bg-primary text-white question-header"
+              as="h6"
+              id={this.props.step['@id']}
+              onMouseEnter={this._onMouseEnterHandler}
+              onMouseLeave={this._onMouseLeaveHandler}
+          >
             {JsonLdUtils.getLocalized(this.props.step[JsonLdUtils.RDFS_LABEL], this.props.options.intl)}
-            {Question.renderIcons(question, options, this.onCommentChange)}
+            {Question.renderIcons(question, options, this.onCommentChange, this.state.showIcon)}
           </Card.Header>
           <Card.Body className={categoryClass}>
             {questionElement}

--- a/src/constants/Constants.js
+++ b/src/constants/Constants.js
@@ -109,11 +109,19 @@ export default class Constants {
   static ICONS = {
     QUESTION_COMMENTS: "questionComments",
     QUESTION_HELP: "questionHelp"
-  }
+  };
 
   static ICON_BEHAVIOR = {
     ENABLE: "enable",
     DISABLE: "disable",
     ON_HOVER: "onHover"
-  }
+  };
+
+  // Default form options
+  static DEFAULT_OPTIONS = {
+    icons: [
+      {id: Constants.ICONS.QUESTION_HELP, behavior:  Constants.ICON_BEHAVIOR.ENABLE},
+      {id: Constants.ICONS.QUESTION_COMMENTS, behavior: Constants.ICON_BEHAVIOR.ON_HOVER}
+    ]
+  };
 }

--- a/src/styles/s-forms.css
+++ b/src/styles/s-forms.css
@@ -158,6 +158,10 @@ input:disabled {
   max-width: 31.25rem;
 }
 
+.card-header {
+  height: 3rem;
+}
+
 .card-header:first-child {
   line-height: 24px;
 }
@@ -191,6 +195,10 @@ input:disabled {
 
 .card-header .form-group {
   margin-bottom: 0;
+}
+
+.emphasise-on-relevant-short {
+  animation: emphasiseOnRelevant 0.5s ease-in;
 }
 
 .emphasise-on-relevant {

--- a/src/styles/s-forms.css
+++ b/src/styles/s-forms.css
@@ -197,8 +197,8 @@ input:disabled {
   margin-bottom: 0;
 }
 
-.emphasise-on-relevant-short {
-  animation: emphasiseOnRelevant 0.5s ease-in;
+.emphasise-on-relevant-icon {
+  animation: emphasiseOnRelevantIcon 0.5s ease-in;
 }
 
 .emphasise-on-relevant {
@@ -308,6 +308,34 @@ input:disabled {
     display: block;
     opacity: 1;
     background-color: #e6f9fb;
+  }
+}
+
+@keyframes emphasiseOnRelevantIcon {
+  0% {
+    display: none;
+    opacity: 0;
+  }
+
+  1% {
+    display: block;
+    opacity: 0;
+  }
+
+  25% {
+    display: block;
+    opacity: 0;
+  }
+
+  75% {
+    display: block;
+    opacity: 1;
+  }
+
+  100% {
+    display: block;
+    opacity: 1;
+    background-color: transparent;
   }
 }
 


### PR DESCRIPTION
This pull request refers to issues #65 and #73. 

Icons can be parameterized to be always shown, never shown, or shown on hover. By default, help icons will be always shown and question comment icons will be shown on hover.