### PR TITLE
Fix external link icon layout clashing with ofn-record-manager

### DIFF
--- a/src/styles/icons/ExternalLink.jsx
+++ b/src/styles/icons/ExternalLink.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 const ExternalLink = () => (
     <svg
-        className="external-link"
+        className="external-link-icon"
         width="16"
         height="16"
         viewBox="0 0 16 16"

--- a/src/styles/s-forms.css
+++ b/src/styles/s-forms.css
@@ -62,13 +62,13 @@ svg {
 
 .question-circle,
 .question-comment,
-.external-link {
+.external-link-icon {
   fill: grey;
 }
 
 .text-white .question-circle,
 .text-white .question-comment,
-.text-white .external-link {
+.text-white .external-link-icon {
   fill: white;
 }
 


### PR DESCRIPTION
External link icon classname was clashing with a a similar classname in the ofn-record-manager