### PR TITLE
Make link icon wider to create space with label

### DIFF
--- a/src/styles/icons/ExternalLink.jsx
+++ b/src/styles/icons/ExternalLink.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 const ExternalLink = () => (
     <svg
         className="external-link-icon"
-        width="16"
+        width="24"
         height="16"
         viewBox="0 0 16 16"
         xmlns="http://www.w3.org/2000/svg">


### PR DESCRIPTION
When link icon was the first icon, there was no space with label.