### PR TITLE
Text area in comments expands when key is hold

### DIFF
--- a/src/components/comment/CommentForm.jsx
+++ b/src/components/comment/CommentForm.jsx
@@ -29,10 +29,10 @@ const CommentForm = (props) => {
     e.stopPropagation();
   };
 
-    const autoResizeTextArea = (e) => {
-        const textArea = document.getElementById("comment-form");
+    const autoResizeTextArea = () => {
+        const textArea = formInputRef.current;
         textArea.style.height = "auto";
-        let scrollHeight = e.target.scrollHeight;
+        let scrollHeight = textArea.scrollHeight;
         textArea.style.height = `${scrollHeight}px`;
     }
 
@@ -51,7 +51,8 @@ const CommentForm = (props) => {
                                 value={commentValue}
                                 onChange={onValueChange}
                                 ref={formInputRef}
-                                onKeyUp={(e => autoResizeTextArea(e))}
+                                onKeyPress={autoResizeTextArea}
+                                onKeyDown={autoResizeTextArea}
                             />
                             <Button className="comment-form-button" variant="primary" type="submit" >
                                 <ArrowRight/>


### PR DESCRIPTION
Related to #93. 
Two event listeners are needed instead of one as `onKeyPress` does not detect backspace, `onKeyDown/onKeyUp` do not detect key hold. 
[https://stackoverflow.com/questions/4843472/javascript-listener-keypress-doesnt-detect-backspace](url)
[https://stackoverflow.com/questions/64240433/keypress-with-backspace-and-delete](url)