### PR TITLE
[fix] use named import, instead of default import

### DIFF
--- a/src/components/FormManager.jsx
+++ b/src/components/FormManager.jsx
@@ -3,7 +3,7 @@ import QuestionAnswerProcessor from "../model/QuestionAnswerProcessor";
 import { FormQuestionsContext } from "../contexts/FormQuestionsContext";
 import Wizard from "./wizard/Wizard";
 import FormWindow from "./FormWindow";
-import Card from "react-bootstrap/Card";
+import { Card } from "react-bootstrap";
 import Question from "./Question";
 import FormUtils from "../util/FormUtils.js";
 


### PR DESCRIPTION
Solve build errors for vitest in record-manager-ui