### PR TITLE
[#458] Fix image fitting and fullscreen button visibility

### DIFF
--- a/src/components/MediaContent.tsx
+++ b/src/components/MediaContent.tsx
@@ -25,6 +25,7 @@ const MediaContent = ({ question, displayAnnotations }: Props) => {
           >
             <MediaAssetViewer
               src={media[Constants.HAS_SOURCE]}
+              mediaId={media["@id"]}
               allowFullScreen
               annotations={media[Constants.HAS_ANNOTATION] ?? []}
               showAnnotations={displayAnnotations}

--- a/src/components/media/MediaAssetViewer.jsx
+++ b/src/components/media/MediaAssetViewer.jsx
@@ -1,4 +1,4 @@
-import React, { useRef } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import ViewerUtils from "../../util/MediaAssetViewerUtils.js";
 import "../../styles/media.css";
 import VideoViewer from "./video/VideoViewer.jsx";
@@ -28,6 +28,7 @@ const IframeViewer = ({ src, allowFullScreen }) => (
  */
 const MediaAssetViewer = ({
   src,
+  mediaId,
   annotations = [],
   allowFullScreen,
   showAnnotations = true,
@@ -35,20 +36,47 @@ const MediaAssetViewer = ({
   const containerRef = useRef(null);
   const { isFullscreen, toggle } = useFullscreen(containerRef);
 
+  // Resolve synchronously from the URL/`@id` hints; fall back to an async probe
+  // only when those are inconclusive (e.g. an extension-less, hint-less URL).
+  const [resolved, setResolved] = useState(() => {
+    const known = ViewerUtils.getMediaKind(src, mediaId);
+    return known && known.kind !== "iframe" ? known : null;
+  });
+
+  useEffect(() => {
+    let cancelled = false;
+    const known = ViewerUtils.getMediaKind(src, mediaId);
+    if (known && known.kind !== "iframe") {
+      setResolved(known);
+      return;
+    }
+    setResolved(null);
+    ViewerUtils.resolveMediaKind(src, mediaId).then((res) => {
+      if (!cancelled) setResolved(res ?? { kind: "iframe", type: null });
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [src, mediaId]);
+
   if (!src) return null;
 
-  const { kind } = ViewerUtils.getMediaKindFromSource(src);
-  const MediaComponent = mediaRegistry[kind] || IframeViewer;
+  const MediaComponent = resolved
+    ? mediaRegistry[resolved.kind] || IframeViewer
+    : null;
 
   return (
     <MediaFullScreenContainer ref={containerRef} fullscreen={isFullscreen}>
-      <MediaComponent
-        src={src}
-        annotations={annotations}
-        allowFullScreen={allowFullScreen}
-        onFullScreen={toggle}
-        showAnnotations={showAnnotations}
-      />
+      {MediaComponent && (
+        <MediaComponent
+          src={src}
+          type={resolved.type}
+          annotations={annotations}
+          allowFullScreen={allowFullScreen}
+          onFullScreen={toggle}
+          showAnnotations={showAnnotations}
+        />
+      )}
     </MediaFullScreenContainer>
   );
 };

--- a/src/components/media/icons/fullscreenIcon.jsx
+++ b/src/components/media/icons/fullscreenIcon.jsx
@@ -1,0 +1,28 @@
+import React from "react";
+
+/**
+ * Standard "enter fullscreen" icon (Material Design `fullscreen`).
+ *
+ * Used for the fullscreen control on external media (image and video) so it
+ * looks consistent with each other and with the native fullscreen button of
+ * mediaCMS-provided players, which use the same iconography (issue #458).
+ */
+const PATH =
+  "M7 14H5v5h5v-2H7v-3zm-2-4h2V7h3V5H5v5zm12 7h-3v2h5v-5h-2v3zM14 5v2h3v3h2V5h-5z";
+
+// Markup string for consumers that render via innerHTML (e.g. Video.js buttons).
+export const fullscreenIconSvg = `<svg viewBox="0 0 24 24" width="20" height="20" fill="currentColor" aria-hidden="true"><path d="${PATH}"/></svg>`;
+
+// React component for JSX consumers.
+export const FullscreenIcon = (props) => (
+  <svg
+    viewBox="0 0 24 24"
+    width="20"
+    height="20"
+    fill="currentColor"
+    aria-hidden="true"
+    {...props}
+  >
+    <path d={PATH} />
+  </svg>
+);

--- a/src/components/media/image/ImageViewer.jsx
+++ b/src/components/media/image/ImageViewer.jsx
@@ -1,6 +1,7 @@
 import React, { useRef } from "react";
 import { useMediaSurface } from "../hooks/useMediaSurface.js";
 import AnnotationOverlay from "../annotation/AnnotationOverlay.jsx";
+import { FullscreenIcon } from "../icons/fullscreenIcon.jsx";
 
 /**
  * Viewer for displaying images with annotations.
@@ -24,8 +25,12 @@ const ImageViewer = ({ src, annotations, onFullScreen, showAnnotations }) => {
           currentTime={null}
         />
       </div>
-      <button className="media-fullscreen-button" onClick={onFullScreen}>
-        ⛶
+      <button
+        className="media-fullscreen-button"
+        onClick={onFullScreen}
+        aria-label="Fullscreen"
+      >
+        <FullscreenIcon />
       </button>
     </div>
   );

--- a/src/components/media/video/hooks/enhancePlayer.js
+++ b/src/components/media/video/hooks/enhancePlayer.js
@@ -1,3 +1,5 @@
+import { fullscreenIconSvg } from "../../icons/fullscreenIcon.jsx";
+
 /**
  * Adds a custom fullscreen button to a Video.js player's control bar.
  * The button is inserted next to an existing control (remaining time display
@@ -13,8 +15,8 @@ const addCustomFullScreenButton = (player, onFullScreen) => {
     : controlBar.children().length;
   const button = controlBar.addChild("button", {}, index + 1);
   const buttonEl = button.el();
-  buttonEl.innerHTML = "⛶";
-  buttonEl.style.fontSize = "20px";
+  buttonEl.innerHTML = fullscreenIconSvg;
+  buttonEl.setAttribute("aria-label", "Fullscreen");
   buttonEl.onclick = () => onFullScreen(player);
 };
 

--- a/src/styles/media.css
+++ b/src/styles/media.css
@@ -79,23 +79,42 @@
 .media-image-container {
   position: relative;
   width: 100%;
-  height: 100%;
   aspect-ratio: 4 / 3;
+  max-height: 100%;
 
   display: flex;
   align-items: center;
   justify-content: center;
+
+  overflow: hidden;
+}
+
+/* In fullscreen the surrounding container drives the size, so let the image
+   area fill it instead of imposing its own aspect ratio. */
+.media-container.fullscreen .media-image-container {
+  height: 100%;
+  aspect-ratio: auto;
+  max-height: none;
 }
 
 .media-image-wrapper {
   position: relative;
   width: 100%;
   height: 100%;
+
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  overflow: hidden;
 }
 
 .media-image-wrapper img {
+  max-width: 100%;
+  max-height: 100%;
   width: 100%;
   height: 100%;
+  object-fit: contain;
 }
 
 /* ============================= */
@@ -118,7 +137,12 @@
   border: none;
   border-radius: 6px;
 
+  font-size: 20px;
+  line-height: 1;
+
   cursor: pointer;
+  /* Hidden by default so it never covers the image; revealed on hover for
+     pointer devices (see the media queries below). */
   opacity: 0;
 
   transition: opacity 0.2s ease, background 0.2s ease, transform 0.15s ease;
@@ -126,9 +150,20 @@
   z-index: 10;
 }
 
-.media-image-container:hover .media-fullscreen-button,
-.media-modal-image-wrapper:hover .media-fullscreen-button {
-  opacity: 1;
+/* Pointer devices (desktop): reveal on hover, like the video control bar. */
+@media (hover: hover) {
+  .media-image-container:hover .media-fullscreen-button,
+  .media-modal-image-wrapper:hover .media-fullscreen-button {
+    opacity: 1;
+  }
+}
+
+/* Touch devices have no hover state, so keep the button reachable. It stays
+   small and tucked in the corner to minimise covering the image. */
+@media (hover: none) {
+  .media-fullscreen-button {
+    opacity: 0.85;
+  }
 }
 
 .media-fullscreen-button:hover {

--- a/src/util/MediaAssetViewerUtils.js
+++ b/src/util/MediaAssetViewerUtils.js
@@ -45,6 +45,126 @@ export default class MediaAssetViewerUtils {
   }
 
   /**
+   * Determines the media kind from an asset identifier. MediaCMS-provided
+   * assets encode the kind in their `@id`
+   * (e.g. `.../media-metadata/video/<id>/asset`), so the kind can be resolved
+   * without inspecting the (extension-less) source URL.
+   *
+   * @param {string} id - Asset `@id`.
+   * @returns {{ kind: "video" | "image", type: string | null } | null}
+   */
+  static getMediaKindFromId(id) {
+    if (!id || typeof id !== "string") return null;
+    const lower = id.toLowerCase();
+
+    if (/\/video\//.test(lower)) {
+      return { kind: "video", type: null };
+    }
+    if (/\/image\//.test(lower)) {
+      return { kind: "image", type: null };
+    }
+    return null;
+  }
+
+  /**
+   * Resolves the media kind synchronously from the information available in the
+   * form data: the source URL extension first, then the asset `@id` hint.
+   * Returns an `iframe` fallback when neither is conclusive.
+   *
+   * @returns {{ kind: "video" | "image" | "iframe", type: string | null }}
+   */
+  static getMediaKind(src, id) {
+    const byUrl = MediaAssetViewerUtils.getMediaKindFromSource(src);
+    if (byUrl && byUrl.kind !== "iframe") {
+      return byUrl;
+    }
+    return MediaAssetViewerUtils.getMediaKindFromId(id) ?? byUrl;
+  }
+
+  /**
+   * Maps an HTTP Content-Type to a media kind.
+   *
+   * @param {string|null} contentType - Raw `Content-Type` header value.
+   * @returns {{ kind: "video" | "image", type: string | null } | null}
+   * The resolved kind, or `null` when the type is not a renderable media type.
+   */
+  static getMediaKindFromContentType(contentType) {
+    if (!contentType) return null;
+    const lower = contentType.toLowerCase();
+
+    if (lower.includes("mpegurl")) {
+      return { kind: "video", type: "application/x-mpegURL" };
+    }
+    if (lower.startsWith("image/")) {
+      return { kind: "image", type: null };
+    }
+    if (lower.startsWith("video/")) {
+      return { kind: "video", type: lower.split(";")[0].trim() };
+    }
+    return null;
+  }
+
+  /**
+   * Reads the `Content-Type` of a source via a lightweight HEAD request.
+   * Returns `null` on any failure (network error, CORS, non-OK response).
+   */
+  static async probeContentType(src) {
+    try {
+      const res = await fetch(src, { method: "HEAD", credentials: "include" });
+      if (!res.ok) return null;
+      return res.headers.get("Content-Type");
+    } catch (e) {
+      return null;
+    }
+  }
+
+  /**
+   * Checks whether a source loads as an image. Works cross-origin without CORS
+   * (an `<img>` load is not CORS-gated), so it is a reliable fallback when the
+   * Content-Type probe is blocked.
+   */
+  static probeIsImage(src) {
+    return new Promise((resolve) => {
+      if (typeof Image === "undefined") {
+        resolve(false);
+        return;
+      }
+      const img = new Image();
+      img.onload = () => resolve(true);
+      img.onerror = () => resolve(false);
+      img.src = src;
+    });
+  }
+
+  /**
+   * Resolves the media kind for a source. Uses the synchronous hints (URL
+   * extension and asset `@id`) first; only when those are inconclusive does it
+   * fall back to the response Content-Type and, if that is unavailable (e.g.
+   * blocked by CORS), to an image-load probe.
+   *
+   * @returns {Promise<{ kind: "video" | "image" | "iframe", type: string | null }>}
+   */
+  static async resolveMediaKind(src, id) {
+    const known = MediaAssetViewerUtils.getMediaKind(src, id);
+    if (known && known.kind !== "iframe") {
+      return known;
+    }
+
+    const byContentType = MediaAssetViewerUtils.getMediaKindFromContentType(
+      await MediaAssetViewerUtils.probeContentType(src)
+    );
+    if (byContentType) {
+      return byContentType;
+    }
+
+    if (await MediaAssetViewerUtils.probeIsImage(src)) {
+      return { kind: "image", type: null };
+    }
+
+    return known;
+  }
+
+  /**
    * Converts normalized annotation points into viewport pixel coordinates.
    *
    * Input points are expected to be normalized (range 0–1) and encoded as

--- a/test/__tests__/ImageViewer.test.js
+++ b/test/__tests__/ImageViewer.test.js
@@ -1,0 +1,29 @@
+import React from "react";
+import { fireEvent, render } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+import ImageViewer from "../../src/components/media/image/ImageViewer";
+
+describe("ImageViewer", () => {
+  const src = "https://example.com/picture.png";
+
+  it("renders the image from the given source", () => {
+    const { container } = render(<ImageViewer src={src} annotations={[]} />);
+    const img = container.querySelector("img");
+    expect(img).toBeInTheDocument();
+    expect(img).toHaveAttribute("src", src);
+  });
+
+  it("renders a fullscreen button and triggers onFullScreen when clicked", () => {
+    const onFullScreen = jest.fn();
+    const { container } = render(
+      <ImageViewer src={src} annotations={[]} onFullScreen={onFullScreen} />
+    );
+
+    const button = container.querySelector(".media-fullscreen-button");
+    expect(button).toBeInTheDocument();
+
+    fireEvent.click(button);
+    expect(onFullScreen).toHaveBeenCalledTimes(1);
+  });
+});

--- a/test/__tests__/MediaAssetViewerUtils.test.js
+++ b/test/__tests__/MediaAssetViewerUtils.test.js
@@ -1,0 +1,88 @@
+import MediaAssetViewerUtils from "../../src/util/MediaAssetViewerUtils";
+
+describe("MediaAssetViewerUtils media kind detection", () => {
+  // Mimics a mediaCMS asset: an extension-less `/by-id/<id>` source whose kind
+  // is only discoverable from the `@id` (or the response Content-Type).
+  const cmsVideoSrc = "https://media.example.com/by-id/video-id";
+  const cmsVideoId =
+    "http://example.com/ontologies/media-metadata/video/video-id/asset";
+  const cmsImageSrc = "https://media.example.com/by-id/image-id";
+  const cmsImageId =
+    "http://example.com/ontologies/media-metadata/image/image-id/asset";
+
+  describe("getMediaKindFromSource", () => {
+    it("detects image and video extensions", () => {
+      expect(MediaAssetViewerUtils.getMediaKindFromSource("a/b.png").kind).toBe(
+        "image"
+      );
+      expect(MediaAssetViewerUtils.getMediaKindFromSource("a/b.mp4").kind).toBe(
+        "video"
+      );
+    });
+
+    it("falls back to iframe for extension-less mediaCMS URLs", () => {
+      expect(
+        MediaAssetViewerUtils.getMediaKindFromSource(cmsVideoSrc).kind
+      ).toBe("iframe");
+      expect(
+        MediaAssetViewerUtils.getMediaKindFromSource(cmsImageSrc).kind
+      ).toBe("iframe");
+    });
+  });
+
+  describe("getMediaKindFromId", () => {
+    it("reads the kind encoded in the mediaCMS asset @id", () => {
+      expect(MediaAssetViewerUtils.getMediaKindFromId(cmsVideoId).kind).toBe(
+        "video"
+      );
+      expect(MediaAssetViewerUtils.getMediaKindFromId(cmsImageId).kind).toBe(
+        "image"
+      );
+    });
+
+    it("returns null when the @id carries no kind", () => {
+      expect(MediaAssetViewerUtils.getMediaKindFromId(undefined)).toBeNull();
+      expect(
+        MediaAssetViewerUtils.getMediaKindFromId("http://example.com/asset")
+      ).toBeNull();
+    });
+  });
+
+  describe("getMediaKind", () => {
+    it("resolves extension-less mediaCMS sources via the @id hint", () => {
+      expect(
+        MediaAssetViewerUtils.getMediaKind(cmsVideoSrc, cmsVideoId).kind
+      ).toBe("video");
+      expect(
+        MediaAssetViewerUtils.getMediaKind(cmsImageSrc, cmsImageId).kind
+      ).toBe("image");
+    });
+
+    it("prefers the URL extension over the @id hint", () => {
+      expect(
+        MediaAssetViewerUtils.getMediaKind("a/b.png", cmsVideoId).kind
+      ).toBe("image");
+    });
+  });
+
+  describe("getMediaKindFromContentType", () => {
+    it("maps image and video content types", () => {
+      expect(
+        MediaAssetViewerUtils.getMediaKindFromContentType("image/png").kind
+      ).toBe("image");
+      const video =
+        MediaAssetViewerUtils.getMediaKindFromContentType("video/mp4");
+      expect(video.kind).toBe("video");
+      expect(video.type).toBe("video/mp4");
+    });
+
+    it("returns null for non-media content types", () => {
+      expect(
+        MediaAssetViewerUtils.getMediaKindFromContentType("text/html")
+      ).toBeNull();
+      expect(
+        MediaAssetViewerUtils.getMediaKindFromContentType(null)
+      ).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
Fixes #458

## Problem
Making an image fullscreen worked in Storybook but not in a real form: the image showed scrollbars and the fullscreen button was not visible. The external viewers' fullscreen button also looked different from the mediaCMS-provided one.

## Root cause
MediaCMS serves media from **extension-less** URLs (`https://…/by-id/<id>`):
- image → `Content-Type: image/png`
- video → `Content-Type: video/mp4`

`getMediaKindFromSource` only inspects the URL string for extensions, so both fell back to the **iframe** viewer. The image therefore rendered as a raw file inside an `<iframe>` (scrollbars, no usable fullscreen button), and the video used the browser's native iframe player instead of the annotated `VideoViewer`. On top of that, `.media-image-container` mixed `height: 100%` with `aspect-ratio: 4/3` (a parent-dependent conflict), and the external fullscreen control used a `⛶` glyph that didn't match the mediaCMS icon.

## Changes
- **Media-kind detection**: resolve the kind from the asset `@id` (mediaCMS encodes it as `…/media-metadata/<image|video>/…`) and, when no synchronous hint is available, from the response `Content-Type` with a CORS-safe `Image()`-load fallback. `MediaContent` now passes the asset `@id`, and the resolved MIME type is threaded through to the video player. MediaCMS images/videos now render through `ImageViewer`/`VideoViewer` (fit + fullscreen button + annotations) instead of a bare iframe.
- **Image sizing**: size `.media-image-container` via `aspect-ratio` + `max-height: 100%` only (same pattern as the iframe viewer), drop the conflicting `height: 100%`, and clip overflow, so the image fits without scrollbars in any host layout. A fullscreen override lets it fill the container in fullscreen; `.media-image-wrapper`/`img` hardened against overflow.
- **Fullscreen button visibility**: hidden by default, revealed on hover for pointer devices (`@media (hover: hover)`) so it never covers the image; kept visible but subtle on touch devices (`@media (hover: none)`, no hover state) so it stays reachable.
- **Consistent icon**: shared standard fullscreen icon (Material `fullscreen`) for both the external image button and the Video.js custom button, matching the mediaCMS/native player iconography.
- Tests for media-kind detection and the image fullscreen button.

## Acceptance criteria
- [x] The image fits the area without scrollbars, the same way as video.
- [x] There is a button to make the image fullscreen.
- [x] The image fullscreen button is visually similar to the video's when external.
- [x] The external and mediaCMS-provided fullscreen buttons look similar (shared standard icon; mediaCMS image/video now use the same viewers).

## Verification
- `npm test` — 14 suites pass (92 passed / 3 skipped), incl. new `MediaAssetViewerUtils` and `ImageViewer` tests.
- Detection verified against the real production assets:
  - `…/by-id/1bjv7…` → `image/png`, `@id` `…/media-metadata/image/…` → ImageViewer
  - `…/by-id/1Gzgc…` → `video/mp4`, `@id` `…/media-metadata/video/…` → VideoViewer