### PR TITLE
[#458] Provide a MIME type for extension-less mediaCMS videos

### DIFF
--- a/src/components/media/MediaAssetViewer.jsx
+++ b/src/components/media/MediaAssetViewer.jsx
@@ -11,6 +11,14 @@ const mediaRegistry = {
   image: ImageViewer,
 };
 
+// A synchronously resolved kind is usable as-is unless it is the iframe
+// fallback or a video missing its MIME type (which Video.js requires); those
+// need the async probe in resolveMediaKind.
+const isDirectlyUsable = (resolved) =>
+  resolved &&
+  resolved.kind !== "iframe" &&
+  !(resolved.kind === "video" && !resolved.type);
+
 const IframeViewer = ({ src, allowFullScreen }) => (
   <div className="media-iframe-container">
     <div className="media-iframe-wrapper">
@@ -37,16 +45,17 @@ const MediaAssetViewer = ({
   const { isFullscreen, toggle } = useFullscreen(containerRef);
 
   // Resolve synchronously from the URL/`@id` hints; fall back to an async probe
-  // only when those are inconclusive (e.g. an extension-less, hint-less URL).
+  // only when those are inconclusive (e.g. an extension-less, hint-less URL, or
+  // a video whose MIME type still has to be determined).
   const [resolved, setResolved] = useState(() => {
     const known = ViewerUtils.getMediaKind(src, mediaId);
-    return known && known.kind !== "iframe" ? known : null;
+    return isDirectlyUsable(known) ? known : null;
   });
 
   useEffect(() => {
     let cancelled = false;
     const known = ViewerUtils.getMediaKind(src, mediaId);
-    if (known && known.kind !== "iframe") {
+    if (isDirectlyUsable(known)) {
       setResolved(known);
       return;
     }

--- a/src/util/MediaAssetViewerUtils.js
+++ b/src/util/MediaAssetViewerUtils.js
@@ -1,3 +1,8 @@
+// Assumed MIME type for a video whose exact type cannot be determined (an
+// extension-less source resolved from the @id, with the Content-Type probe
+// unavailable). Video.js needs a type or it reports "No compatible source".
+const DEFAULT_VIDEO_TYPE = "video/mp4";
+
 /**
  *
  * Utility class providing helper functions for media asset.
@@ -146,6 +151,17 @@ export default class MediaAssetViewerUtils {
    */
   static async resolveMediaKind(src, id) {
     const known = MediaAssetViewerUtils.getMediaKind(src, id);
+
+    // A known video without an explicit MIME type (e.g. an extension-less
+    // source resolved from the @id) needs its type filled in, otherwise
+    // Video.js reports "No compatible source was found for this media".
+    if (known && known.kind === "video" && !known.type) {
+      const byContentType = MediaAssetViewerUtils.getMediaKindFromContentType(
+        await MediaAssetViewerUtils.probeContentType(src)
+      );
+      return { kind: "video", type: byContentType?.type ?? DEFAULT_VIDEO_TYPE };
+    }
+
     if (known && known.kind !== "iframe") {
       return known;
     }

--- a/test/__tests__/MediaAssetViewerUtils.test.js
+++ b/test/__tests__/MediaAssetViewerUtils.test.js
@@ -85,4 +85,38 @@ describe("MediaAssetViewerUtils media kind detection", () => {
       ).toBeNull();
     });
   });
+
+  describe("resolveMediaKind (video MIME type)", () => {
+    let originalFetch;
+    beforeEach(() => {
+      originalFetch = global.fetch;
+    });
+    afterEach(() => {
+      global.fetch = originalFetch;
+    });
+
+    it("fills in the MIME type from the Content-Type for an extension-less video", async () => {
+      global.fetch = jest.fn(() =>
+        Promise.resolve({ ok: true, headers: { get: () => "video/webm" } })
+      );
+      const res = await MediaAssetViewerUtils.resolveMediaKind(
+        cmsVideoSrc,
+        cmsVideoId
+      );
+      expect(res.kind).toBe("video");
+      expect(res.type).toBe("video/webm");
+    });
+
+    it("defaults to video/mp4 when the Content-Type cannot be read", async () => {
+      global.fetch = jest.fn(() =>
+        Promise.reject(new Error("blocked by CORS"))
+      );
+      const res = await MediaAssetViewerUtils.resolveMediaKind(
+        cmsVideoSrc,
+        cmsVideoId
+      );
+      expect(res.kind).toBe("video");
+      expect(res.type).toBe("video/mp4");
+    });
+  });
 });


### PR DESCRIPTION
Follow-up to #459 (already merged).

## Problem
In production a mediaCMS video failed to play with:

> No compatible source was found for this media.

## Root cause
A mediaCMS video is detected as `kind: "video"` from the asset `@id`, but its source URL is **extension-less** (`.../by-id/<id>`) and the type was `null`. Video.js cannot select a source handler from a source with neither an extension nor a MIME type, so it rejects it.

## Fix
- In `resolveMediaKind`, when the kind is `video` but the type is unknown, fill it in: read the exact MIME from the response `Content-Type` (handles `video/mp4`, `video/webm`, …), and fall back to `video/mp4` when that cannot be read (e.g. cross-origin without CORS headers — the `:2081` mediaCMS case).
- `MediaAssetViewer` now routes a "video without a known type" through the async probe (new `isDirectlyUsable` check) instead of rendering it immediately with a null type. The resolved type is threaded to `VideoViewer` → `sources: [{ src, type }]`.

## Tests
Two new cases (mocked `fetch`): the probed `Content-Type` is used, and the `video/mp4` fallback applies when the probe fails. Full suite: 14 suites, 94 passed / 3 skipped.

## Note
The `video/mp4` fallback assumes mp4 when the Content-Type is unreadable, which is correct for this mediaCMS deployment; exact types still win when the probe succeeds. A non-mp4 extension-less video behind CORS would be mislabeled — can switch that ambiguous case back to an iframe if preferred.